### PR TITLE
chore: remove references of nxg-auth-firebase-auth

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "@angular/service-worker": "^16.2.3",
         "firebase": "^9.23.0",
         "first-input-delay": "^0.1.3",
-        "ngx-auth-firebaseui": "^7.1.0",
         "proxy-polyfill": "^0.3.2",
         "rxjs": "^6.6.7",
         "tslib": "^2.2.0",
@@ -23143,30 +23142,6 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
-    },
-    "node_modules/ngx-auth-firebaseui": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/ngx-auth-firebaseui/-/ngx-auth-firebaseui-7.1.0.tgz",
-      "integrity": "sha512-fHwVhdBkvxsNWpN4zKwcqq82WsdEB5xXNxNVhvayajK1OdaEK6LaCLZFycIhS/mfy5X3ufN1rIf4ctX2QK846w==",
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@angular-material-extensions/password-strength": "^11.x",
-        "@angular/animations": "^14.x",
-        "@angular/cdk": "^14.0.0",
-        "@angular/common": "^14.x",
-        "@angular/core": "^14.x",
-        "@angular/fire": "^7.x",
-        "@angular/flex-layout": "^14.0.0-beta.41",
-        "@angular/forms": "^14.x",
-        "@angular/material": "^14.0.0",
-        "@angular/router": "^14.x",
-        "firebase": "^9.x"
-      }
     },
     "node_modules/nice-napi": {
       "version": "1.0.2",
@@ -47750,14 +47725,6 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
-    },
-    "ngx-auth-firebaseui": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/ngx-auth-firebaseui/-/ngx-auth-firebaseui-7.1.0.tgz",
-      "integrity": "sha512-fHwVhdBkvxsNWpN4zKwcqq82WsdEB5xXNxNVhvayajK1OdaEK6LaCLZFycIhS/mfy5X3ufN1rIf4ctX2QK846w==",
-      "requires": {
-        "tslib": "^2.0.0"
-      }
     },
     "nice-napi": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "@angular/service-worker": "^16.2.3",
     "firebase": "^9.23.0",
     "first-input-delay": "^0.1.3",
-    "ngx-auth-firebaseui": "^7.1.0",
     "proxy-polyfill": "^0.3.2",
     "rxjs": "^6.6.7",
     "tslib": "^2.2.0",

--- a/projects/web/src/app/app.component.spec.ts
+++ b/projects/web/src/app/app.component.spec.ts
@@ -23,7 +23,6 @@ import { MatLegacySnackBarModule as MatSnackBarModule } from '@angular/material/
 import { AngularFireModule } from '@angular/fire/compat';
 import { environment } from '../environments/environment';
 import { HttpClientModule } from '@angular/common/http';
-import { NgxAuthFirebaseUIModule } from 'ngx-auth-firebaseui';
 
 describe('AppComponent', () => {
   beforeEach(waitForAsync(() => {
@@ -33,7 +32,6 @@ describe('AppComponent', () => {
         RouterTestingModule.withRoutes(routes),
         HttpClientModule,
         AngularFireModule.initializeApp(environment.firebase),
-        NgxAuthFirebaseUIModule.forRoot(environment.firebase),
         MatSidenavModule,
         MatToolbarModule,
         MatIconModule,

--- a/projects/web/src/app/app.module.ts
+++ b/projects/web/src/app/app.module.ts
@@ -15,7 +15,6 @@ import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { PreloadAllModules, RouterModule, Routes } from '@angular/router';
 import { ServiceWorkerModule } from '@angular/service-worker';
-import { NgxAuthFirebaseUIModule } from 'ngx-auth-firebaseui';
 
 import { environment } from '../environments/environment';
 
@@ -72,8 +71,6 @@ export const routes: Routes = [
     AngularFireModule.initializeApp(environment.firebase),
     AngularFireAnalyticsModule,
     AngularFirePerformanceModule,
-    // TODO configure settings: https://github.com/anthonynahas/ngx-auth-firebaseui#configuration
-    NgxAuthFirebaseUIModule.forRoot(environment.firebase),
     LayoutModule,
     MatToolbarModule,
     MatButtonModule,

--- a/projects/web/src/app/auth/auth.component.html
+++ b/projects/web/src/app/auth/auth.component.html
@@ -1,34 +1,3 @@
 <main class="auth-container">
-  <ngx-auth-firebaseui
-    [providers]="[providers.Google]"
-    (onSuccess)="onSuccess()"
-    (onError)="onError($event)"
-    signInTabText="Registrarse"
-    signInCardTitleText="Iniciando sesión"
-    loginButtonText="Iniciar sesión"
-    forgotPasswordButtonText="Se te olvidó tu contraseña ?"
-    nameText="Nombre"
-    nameErrorRequiredText="Se requiere el nombre"
-    nameErrorMinLengthText="¡El nombre es demasiado corto!"
-    nameErrorMaxLengthText="¡El nombre es muy largo!"
-    emailText="Email"
-    emailErrorRequiredText="Correo electronico es requerido"
-    emailErrorPatternText="Por favor, introduce una dirección de correo electrónico válida"
-    passwordText="Contraseña"
-    passwordErrorRequiredText="se requiere contraseña"
-    registerTabText="Registro"
-    registerCardTitleText="Registro"
-    registerButtonText="Registro"
-    guestButtonText="continua como invitado"
-    resetPasswordTabText="Restablecer la dirección de correo electrónico a la contraseña"
-    resetPasswordInputText="Restablecer la dirección de correo electrónico a la contraseña"
-    resetPasswordErrorRequiredText="Se requiere un correo electrónico para restablecer la contraseña!"
-    resetPasswordErrorPatternText="Por favor, introduce una dirección de correo electrónico válida"
-    resetPasswordActionButtonText="Reiniciar"
-    resetPasswordInstructionsText="Restablecimiento solicitado. Revise sus instrucciones de correo electrónico."
-    emailConfirmationTitle="¡Confirme su dirección de correo electrónico!"
-    emailConfirmationText="Se le ha enviado un correo electrónico de confirmación.\n   Revise su bandeja de entrada y haga clic en el enlace \ Confirmar mi correo electrónico\\ para confirmar su dirección de correo electrónico."
-  >
-  </ngx-auth-firebaseui>
   <mat-divider></mat-divider>
 </main>

--- a/projects/web/src/app/auth/auth.component.scss
+++ b/projects/web/src/app/auth/auth.component.scss
@@ -1,14 +1,4 @@
-// Take care: this component has ViewEncapsulation.None
 main.auth-container {
   max-width: 800px;
   margin-bottom: 64px;
-
-  ngx-auth-firebaseui {
-    display: block;
-    border-right: rgba(0, 0, 0, 0.12) solid 1px;
-
-    mat-icon {
-      vertical-align: middle !important;
-    }
-  }
 }

--- a/projects/web/src/app/auth/auth.component.spec.ts
+++ b/projects/web/src/app/auth/auth.component.spec.ts
@@ -4,7 +4,6 @@ import { AuthComponent } from './auth.component';
 import { AngularFireModule } from '@angular/fire/compat';
 import { environment } from '../../environments/environment';
 import { RouterTestingModule } from '@angular/router/testing';
-import { NgxAuthFirebaseUIModule } from 'ngx-auth-firebaseui';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MatDividerModule } from '@angular/material/divider';
 
@@ -18,7 +17,6 @@ describe('AuthComponent', () => {
         NoopAnimationsModule,
         AngularFireModule.initializeApp(environment.firebase),
         RouterTestingModule,
-        NgxAuthFirebaseUIModule.forRoot(environment.firebase),
         MatDividerModule
       ],
       declarations: [AuthComponent]

--- a/projects/web/src/app/auth/auth.component.ts
+++ b/projects/web/src/app/auth/auth.component.ts
@@ -1,23 +1,8 @@
-import { Component, ViewEncapsulation } from '@angular/core';
-import { AuthProvider } from 'ngx-auth-firebaseui';
-import { Router } from '@angular/router';
+import { Component } from '@angular/core';
 
 @Component({
   selector: 'app-auth',
   templateUrl: './auth.component.html',
-  styleUrls: ['./auth.component.scss'],
-  encapsulation: ViewEncapsulation.None
+  styleUrls: ['./auth.component.scss']
 })
-export class AuthComponent {
-  providers = AuthProvider;
-
-  constructor(private router: Router) {}
-
-  onSuccess() {
-    this.router.navigate(['/']);
-  }
-
-  onError(event: any) {
-    console.error(event);
-  }
-}
+export class AuthComponent {}

--- a/projects/web/src/app/code-of-conduct/code-of-conduct.component.spec.ts
+++ b/projects/web/src/app/code-of-conduct/code-of-conduct.component.spec.ts
@@ -5,8 +5,6 @@ import { HttpClientModule } from '@angular/common/http';
 import { RouterTestingModule } from '@angular/router/testing';
 import { MatIconModule } from '@angular/material/icon';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { NgxAuthFirebaseUIModule } from 'ngx-auth-firebaseui';
-import { environment } from '../../environments/environment';
 
 describe('CodeOfConductComponent', () => {
   let component: CodeOfConductComponent;
@@ -14,13 +12,7 @@ describe('CodeOfConductComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [
-        HttpClientModule,
-        RouterTestingModule,
-        NoopAnimationsModule,
-        MatIconModule,
-        NgxAuthFirebaseUIModule.forRoot(environment.firebase)
-      ],
+      imports: [HttpClientModule, RouterTestingModule, NoopAnimationsModule, MatIconModule],
       declarations: [CodeOfConductComponent]
     }).compileComponents();
   }));

--- a/projects/web/src/app/conferences/conferences.component.spec.ts
+++ b/projects/web/src/app/conferences/conferences.component.spec.ts
@@ -3,8 +3,6 @@ import { MatLegacyButtonModule as MatButtonModule } from '@angular/material/lega
 import { MatLegacyCardModule as MatCardModule } from '@angular/material/legacy-card';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
-import { NgxAuthFirebaseUIModule } from 'ngx-auth-firebaseui';
-import { environment } from '../../environments/environment';
 
 import { ConferencesComponent } from './conferences.component';
 
@@ -14,13 +12,7 @@ describe('ConferencesComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [
-        MatCardModule,
-        NgxAuthFirebaseUIModule.forRoot(environment.firebase),
-        NoopAnimationsModule,
-        MatButtonModule,
-        RouterTestingModule
-      ],
+      imports: [MatCardModule, NoopAnimationsModule, MatButtonModule, RouterTestingModule],
       declarations: [ConferencesComponent]
     }).compileComponents();
   }));

--- a/projects/web/src/app/footer/footer.component.spec.ts
+++ b/projects/web/src/app/footer/footer.component.spec.ts
@@ -4,8 +4,6 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { FooterComponent } from './footer.component';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { HttpClientModule } from '@angular/common/http';
-import { NgxAuthFirebaseUIModule } from 'ngx-auth-firebaseui';
-import { environment } from '../../environments/environment';
 import { MatIconModule } from '@angular/material/icon';
 
 describe('FooterComponent', () => {
@@ -14,13 +12,7 @@ describe('FooterComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [
-        RouterTestingModule,
-        NoopAnimationsModule,
-        HttpClientModule,
-        NgxAuthFirebaseUIModule.forRoot(environment.firebase),
-        MatIconModule
-      ],
+      imports: [RouterTestingModule, NoopAnimationsModule, HttpClientModule, MatIconModule],
       declarations: [FooterComponent]
     }).compileComponents();
   }));

--- a/projects/web/src/app/landing/landing.component.spec.ts
+++ b/projects/web/src/app/landing/landing.component.spec.ts
@@ -3,8 +3,6 @@ import { MatIconModule } from '@angular/material/icon';
 
 import { LandingComponent } from './landing.component';
 import { SponsorsComponent } from '../sponsors/sponsors.component';
-import { NgxAuthFirebaseUIModule } from 'ngx-auth-firebaseui';
-import { environment } from '../../environments/environment';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { HttpClientModule } from '@angular/common/http';
 import { RouterTestingModule } from '@angular/router/testing';
@@ -15,13 +13,7 @@ describe('LandingComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [
-        NgxAuthFirebaseUIModule.forRoot(environment.firebase),
-        NoopAnimationsModule,
-        RouterTestingModule,
-        HttpClientModule,
-        MatIconModule
-      ],
+      imports: [NoopAnimationsModule, RouterTestingModule, HttpClientModule, MatIconModule],
       declarations: [LandingComponent, SponsorsComponent]
     }).compileComponents();
   }));

--- a/projects/web/src/app/meetups/meetups.component.spec.ts
+++ b/projects/web/src/app/meetups/meetups.component.spec.ts
@@ -1,8 +1,6 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { MeetupsComponent } from './meetups.component';
 import { MatLegacyCardModule as MatCardModule } from '@angular/material/legacy-card';
-import { NgxAuthFirebaseUIModule } from 'ngx-auth-firebaseui';
-import { environment } from '../../environments/environment';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 import { HttpClientModule } from '@angular/common/http';
@@ -13,13 +11,7 @@ describe('MeetupsComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [
-        MatCardModule,
-        NgxAuthFirebaseUIModule.forRoot(environment.firebase),
-        NoopAnimationsModule,
-        RouterTestingModule,
-        HttpClientModule
-      ],
+      imports: [MatCardModule, NoopAnimationsModule, RouterTestingModule, HttpClientModule],
       declarations: [MeetupsComponent]
     }).compileComponents();
   }));

--- a/projects/web/src/app/nav/nav.component.spec.ts
+++ b/projects/web/src/app/nav/nav.component.spec.ts
@@ -14,7 +14,6 @@ import { FooterComponent } from '../footer/footer.component';
 import { AngularFireModule } from '@angular/fire/compat';
 import { environment } from '../../environments/environment';
 import { HttpClientModule } from '@angular/common/http';
-import { NgxAuthFirebaseUIModule } from 'ngx-auth-firebaseui';
 
 describe('NavComponent', () => {
   let component: NavComponent;
@@ -29,7 +28,6 @@ describe('NavComponent', () => {
         HttpClientModule,
         LayoutModule,
         AngularFireModule.initializeApp(environment.firebase),
-        NgxAuthFirebaseUIModule.forRoot(environment.firebase),
         MatButtonModule,
         MatIconModule,
         MatListModule,

--- a/projects/web/src/app/organize-meetup/organize-meetup.component.spec.ts
+++ b/projects/web/src/app/organize-meetup/organize-meetup.component.spec.ts
@@ -4,8 +4,6 @@ import { OrganizeMeetupComponent } from './organize-meetup.component';
 import { HttpClientModule } from '@angular/common/http';
 import { RouterTestingModule } from '@angular/router/testing';
 import { MatIconModule } from '@angular/material/icon';
-import { NgxAuthFirebaseUIModule } from 'ngx-auth-firebaseui';
-import { environment } from '../../environments/environment';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('OrganizeMeetupComponent', () => {
@@ -14,13 +12,7 @@ describe('OrganizeMeetupComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [
-        HttpClientModule,
-        RouterTestingModule,
-        NgxAuthFirebaseUIModule.forRoot(environment.firebase),
-        NoopAnimationsModule,
-        MatIconModule
-      ],
+      imports: [HttpClientModule, RouterTestingModule, NoopAnimationsModule, MatIconModule],
       declarations: [OrganizeMeetupComponent]
     }).compileComponents();
   }));

--- a/projects/web/src/app/page-not-found/page-not-found.component.spec.ts
+++ b/projects/web/src/app/page-not-found/page-not-found.component.spec.ts
@@ -3,8 +3,6 @@ import { MatIconModule } from '@angular/material/icon';
 
 import { PageNotFoundComponent } from './page-not-found.component';
 import { RouterTestingModule } from '@angular/router/testing';
-import { NgxAuthFirebaseUIModule } from 'ngx-auth-firebaseui';
-import { environment } from '../../environments/environment';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { HttpClientModule } from '@angular/common/http';
 
@@ -19,7 +17,6 @@ describe('PageNotFoundComponent', () => {
         MatIconModule,
         NoopAnimationsModule,
         HttpClientModule,
-        NgxAuthFirebaseUIModule.forRoot(environment.firebase),
         MatIconModule
       ],
       declarations: [PageNotFoundComponent]

--- a/projects/web/src/app/top-nav/top-nav.component.html
+++ b/projects/web/src/app/top-nav/top-nav.component.html
@@ -14,12 +14,4 @@
     src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNTAgMjUwIj4KICAgIDxwYXRoIGZpbGw9IiNERDAwMzEiIGQ9Ik0xMjUgMzBMMzEuOSA2My4ybDE0LjIgMTIzLjFMMTI1IDIzMGw3OC45LTQzLjcgMTQuMi0xMjMuMXoiIC8+CiAgICA8cGF0aCBmaWxsPSIjQzMwMDJGIiBkPSJNMTI1IDMwdjIyLjItLjFWMjMwbDc4LjktNDMuNyAxNC4yLTEyMy4xTDEyNSAzMHoiIC8+CiAgICA8cGF0aCAgZmlsbD0iI0ZGRkZGRiIgZD0iTTEyNSA1Mi4xTDY2LjggMTgyLjZoMjEuN2wxMS43LTI5LjJoNDkuNGwxMS43IDI5LjJIMTgzTDEyNSA1Mi4xem0xNyA4My4zaC0zNGwxNy00MC45IDE3IDQwLjl6IiAvPgogIDwvc3ZnPg=="
   /><span>ngular Hispano</span>
   <span style="flex: auto"></span>
-  <!-- ngx-auth-firebaseui does not work properly with Angular v16.
-  We opened an issue to fix it
-  https://github.com/angular-hispano/angular-hispano/issues/235 -->
-  <!-- <ngx-auth-firebaseui-avatar *ngIf="auth.user | async; else showLogin">
-  </ngx-auth-firebaseui-avatar>
-  <ng-template #showLogin>
-    <a mat-button [routerLink]="['auth']"><span>Iniciar</span><span id="session"> Sesión</span></a>
-  </ng-template> -->
 </mat-toolbar>

--- a/projects/web/src/app/top-nav/top-nav.component.spec.ts
+++ b/projects/web/src/app/top-nav/top-nav.component.spec.ts
@@ -8,7 +8,6 @@ import { environment } from '../../environments/environment';
 import { RouterTestingModule } from '@angular/router/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { HttpClientModule } from '@angular/common/http';
-import { NgxAuthFirebaseUIModule } from 'ngx-auth-firebaseui';
 
 describe('TopNavComponent', () => {
   let component: TopNavComponent;
@@ -21,7 +20,6 @@ describe('TopNavComponent', () => {
         AngularFireModule.initializeApp(environment.firebase),
         RouterTestingModule,
         HttpClientModule,
-        NgxAuthFirebaseUIModule.forRoot(environment.firebase),
         MatIconModule,
         MatToolbarModule
       ],

--- a/projects/web/src/app/top-nav/top-nav.component.ts
+++ b/projects/web/src/app/top-nav/top-nav.component.ts
@@ -1,6 +1,5 @@
 import { Component } from '@angular/core';
 import { NavService } from '../nav.service';
-import { AngularFireAuth } from '@angular/fire/compat/auth';
 
 @Component({
   selector: 'app-top-nav',
@@ -8,5 +7,5 @@ import { AngularFireAuth } from '@angular/fire/compat/auth';
   styleUrls: ['./top-nav.component.scss']
 })
 export class TopNavComponent {
-  constructor(public navService: NavService, public auth: AngularFireAuth) {}
+  constructor(public navService: NavService) {}
 }


### PR DESCRIPTION
- Eliminar dependencia de `ngx-auth-firebase-ui`
- Eliminar referencias de las prueba unitaria.
- Limpiar el componente de autenticación.

Agregaremos una nueva función de autenticación en el futuro.

#235 